### PR TITLE
feat(defillama): Add method for fetching historical TVL per chain

### DIFF
--- a/defillama/defillama.py
+++ b/defillama/defillama.py
@@ -107,3 +107,15 @@ class DefiLlama:
         path = f'/chains/'
 
         return self._get(path)
+
+    def get_chain_tvl(self, chain):
+        """
+        Returns historical values of the TVL for the given chain.
+        Endpoint: GET /charts/{chain}
+
+        :param: chain : the chain to return TVL for, e.g. ethereum
+        :return: JSON response
+        """
+        path = f'/charts/{chain}'
+
+        return self._get(path)

--- a/tests/test_defillama.py
+++ b/tests/test_defillama.py
@@ -38,3 +38,8 @@ class TestDefiLlama:
     def test_get_protocol_tvl(self, llama):
         response = llama.get_protocol_tvl(name='uniswap')
         assert type(response) is float
+
+    # @pytest.mark.skip(reason='TBD')
+    def test_get_chain_tvl(self, llama):
+        response = llama.get_chain_tvl('ethereum')
+        assert type(response) is list


### PR DESCRIPTION
### Description
Add a method to the client to fetch historical TVL data for a single chain by using the `/charts/<chain>` [endpoint](https://defillama.com/docs/api). 