### PR TITLE
Fix protocol fees endpoint

### DIFF
--- a/defillama/__version__.py
+++ b/defillama/__version__.py
@@ -2,7 +2,7 @@
 __title__ = 'DeFiLlama'
 __description__ = 'Unofficial DeFi Llama API client.'
 __url__ = 'https://github.com/itzmestar/DeFiLlama'
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 __build__ = 0x010001
 __author__ = 'Tarique Anwer'
 __author_email__ = 'itzmetariq@gmail.com'

--- a/defillama/defillama.py
+++ b/defillama/defillama.py
@@ -110,7 +110,7 @@ class DefiLlama:
     def get_chains_current_tvl(self):
         """
         Returns list of current TVL of all chains.
-        
+
         :return: JSON response
         """
         path = f'/v2/chains'
@@ -330,12 +330,14 @@ class DefiLlama:
 
         return self._get(path, params=params)
 
-    def get_fees_protocol(self, protocol, dataType='dailyFees'):
+    def get_fees_protocol(self, protocol, dataType='dailyFees', excludeTotalDataChart=True, excludeTotalDataChartBreakdown=True):
         """
             Get summary of protocol fees and revenue with historical data
         """
-        path = f'/overview/fees/{protocol}'
+        path = f'/summary/fees/{protocol}'
         params = {
+            'excludeTotalDataChart': excludeTotalDataChart,
+            'excludeTotalDataChartBreakdown': excludeTotalDataChartBreakdown,
             'dataType': dataType
         }
 

--- a/defillama/defillama.py
+++ b/defillama/defillama.py
@@ -330,14 +330,12 @@ class DefiLlama:
 
         return self._get(path, params=params)
 
-    def get_fees_protocol(self, protocol, dataType='dailyFees', excludeTotalDataChart=True, excludeTotalDataChartBreakdown=True):
+    def get_fees_protocol(self, protocol, dataType='dailyFees'):
         """
             Get summary of protocol fees and revenue with historical data
         """
         path = f'/summary/fees/{protocol}'
         params = {
-            'excludeTotalDataChart': excludeTotalDataChart,
-            'excludeTotalDataChartBreakdown': excludeTotalDataChartBreakdown,
             'dataType': dataType
         }
 

--- a/tests/test_defillama.py
+++ b/tests/test_defillama.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import pytest
 
 


### PR DESCRIPTION
Protocol fees endpoint has `summary` instead of `overview`.
Updated the url and added params for excluding data charts as other endpoints have.

<img width="1071" alt="Screenshot 2024-04-30 at 15 16 31" src="https://github.com/itzmestar/DeFiLlama/assets/10870130/aa7e6b6a-8aa6-424e-a454-a279bb4864b5">
